### PR TITLE
Add product variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a lightweight demo frontend inspired by online grocery apps. It now incl
 
 ## Getting Started
 
-Open `src/auth/login.html` to sign in. A demo account is provided (`user@example.com`/`demo`). After logging in you can browse the catalog via `src/index.html`. The page now supports theme switching, language selection (English/Spanish) and a filter sheet with tags. Use the search bar with autocomplete, filters, and sorting to explore items. Ratings and reviews are stored locally.
+Open `src/auth/login.html` to sign in. A demo account is provided (`user@example.com`/`demo`). After logging in you can browse the catalog via `src/index.html`. The page now supports theme switching, language selection (English/Spanish) and a filter sheet with tags. Use the search bar with autocomplete, filters, and sorting to explore items. Ratings and reviews are stored locally. Products now include selectable variants (e.g. 500g, 1kg).
 
 Checkout is available through `src/checkout.html` where promo codes and delivery slots can be tested. Order status can be viewed from `src/orders.html`. Notifications and offline detection are enabled.
 

--- a/src/app.js
+++ b/src/app.js
@@ -39,6 +39,7 @@ function openModal(product) {
     <img src="${product.image}" alt="${product.name}" />
     <h2>${product.name}</h2>
     <p>${product.description}</p>
+    ${product.variants ? `<select id="variantSelect">${product.variants.map((v,i)=>`<option value="${i}">${v.label} - $${v.price.toFixed(2)}</option>`).join('')}</select>` : ''}
     <button onclick="addToCart(${product.id})">Add to cart</button>
     <h3>Leave a review</h3>
     <form id="reviewForm">
@@ -70,8 +71,10 @@ function openModal(product) {
 function closeModal() { $('#modal').classList.add('hidden'); }
 
 function addToCart(id) {
+  const select = document.getElementById('variantSelect');
+  const variant = select ? +select.value : null;
   const cart = JSON.parse(localStorage.getItem('cart') || '[]');
-  cart.push(id);
+  cart.push({ id, variant });
   localStorage.setItem('cart', JSON.stringify(cart));
   toast('Item added');
   closeModal();

--- a/src/products.js
+++ b/src/products.js
@@ -1,6 +1,62 @@
 const products = [
-  { id: 1, name: 'Apple', brand: 'FarmFresh', category: 'Fruits', price: 2.5, popularity: 5, stock: 10, image: 'https://via.placeholder.com/200?text=Apple', description: 'Fresh apples from local farms.' },
-  { id: 2, name: 'Banana', brand: 'Tropico', category: 'Fruits', price: 1.2, popularity: 3, stock: 0, image: 'https://via.placeholder.com/200?text=Banana', description: 'Organic bananas rich in potassium.' },
-  { id: 3, name: 'Carrot', brand: 'VeggieFarm', category: 'Vegetables', price: 0.9, popularity: 4, stock: 25, image: 'https://via.placeholder.com/200?text=Carrot', description: 'Crunchy carrots full of vitamins.' },
-  { id: 4, name: 'Milk', brand: 'DairyBest', category: 'Dairy', price: 3.0, popularity: 5, stock: 5, image: 'https://via.placeholder.com/200?text=Milk', description: 'Dairy milk with full cream.' },
+  {
+    id: 1,
+    name: 'Apple',
+    brand: 'FarmFresh',
+    category: 'Fruits',
+    price: 2.5,
+    variants: [
+      { label: '500g', price: 2.5 },
+      { label: '1kg', price: 4.5 }
+    ],
+    popularity: 5,
+    stock: 10,
+    image: 'https://via.placeholder.com/200?text=Apple',
+    description: 'Fresh apples from local farms.'
+  },
+  {
+    id: 2,
+    name: 'Banana',
+    brand: 'Tropico',
+    category: 'Fruits',
+    price: 1.2,
+    variants: [
+      { label: '500g', price: 1.2 },
+      { label: '1kg', price: 2.2 }
+    ],
+    popularity: 3,
+    stock: 0,
+    image: 'https://via.placeholder.com/200?text=Banana',
+    description: 'Organic bananas rich in potassium.'
+  },
+  {
+    id: 3,
+    name: 'Carrot',
+    brand: 'VeggieFarm',
+    category: 'Vegetables',
+    price: 0.9,
+    variants: [
+      { label: '500g', price: 0.9 },
+      { label: '1kg', price: 1.6 }
+    ],
+    popularity: 4,
+    stock: 25,
+    image: 'https://via.placeholder.com/200?text=Carrot',
+    description: 'Crunchy carrots full of vitamins.'
+  },
+  {
+    id: 4,
+    name: 'Milk',
+    brand: 'DairyBest',
+    category: 'Dairy',
+    price: 3.0,
+    variants: [
+      { label: '1L', price: 3.0 },
+      { label: '2L', price: 5.5 }
+    ],
+    popularity: 5,
+    stock: 5,
+    image: 'https://via.placeholder.com/200?text=Milk',
+    description: 'Dairy milk with full cream.'
+  }
 ];


### PR DESCRIPTION
## Summary
- add product variant options in the product data
- display variant selector in product modal
- store selected variant when adding to cart
- document variant feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b2a8945908333b07cd7fd2efba6f4