### PR TITLE
Update loginUrl logic

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,6 +25,7 @@
       <option value="es">ES</option>
     </select>
     <a href="auth/profile.html" class="icon-link">👤</a>
+    <a href="/src/auth/login.html">Login</a>
     <a href="checkout.html" class="icon-link">🛒</a>
     <label><input type="checkbox" id="darkToggle"> Dark</label>
   </header>

--- a/src/auth/auth.js
+++ b/src/auth/auth.js
@@ -18,11 +18,13 @@ function getToken() {
 }
 
 function loginUrl() {
-  const match = location.pathname.match(/^(.*\/src\/)/);
-  if (match) {
-    return match[1] + 'auth/login.html';
+  const pathParts = location.pathname.split('/');
+  const srcIndex = pathParts.indexOf('src');
+  if (srcIndex !== -1) {
+    return (
+      '/' + pathParts.slice(0, srcIndex + 1).join('/') + '/auth/login.html'
+    );
   }
-  // default to an absolute path in case the current page isn't under /src/
   return '/src/auth/login.html';
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,7 @@
       <option value="es">ES</option>
     </select>
     <a href="auth/profile.html" class="icon-link">👤</a>
+    <a href="/src/auth/login.html">Login</a>
     <a href="checkout.html" class="icon-link">🛒</a>
     <label><input type="checkbox" id="darkToggle"> Dark</label>
   </header>


### PR DESCRIPTION
## Summary
- adjust `loginUrl` to compute path using path segments rather than regex
- add `Login` anchor to the home page for quick testing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b445085988333971616cb42f533d5