### PR TITLE
Implement category sheet overlay

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -31,7 +31,7 @@ function renderProducts(list) {
   const cart = getCart();
   list.forEach(p => {
     const card = document.createElement('div');
-    card.className = 'product-card';
+    card.className = 'card';
     const cartItem = cart.find(i => i.id === p.id && i.variant === null);
     const qty = cartItem ? cartItem.qty : 0;
     if (p.stock === 0) {
@@ -40,43 +40,37 @@ function renderProducts(list) {
       card.classList.add('in-stock');
     }
     const discount = p.mrp ? Math.round((1 - p.price / p.mrp) * 100) : 0;
+    const qtyLabel = p.variants && p.variants[0] ? p.variants[0].label : '1 pc';
     card.innerHTML = `
-      <div class="image-container">
-        <img src="${p.image}" alt="${p.name}" loading="lazy" onerror="this.onerror=null;this.src='https://via.placeholder.com/150'" />
-        ${discount > 0 ? `<span class="offer-tag">${discount}% OFF</span>` : ''}
-        <div class="qty-controls ${qty ? '' : 'hidden'}">
-          <button class="qty-btn minus">-</button>
-          <span class="qty">${qty}</span>
-          <button class="qty-btn plus">+</button>
-        </div>
-      </div>
-      <div class="delivery-label"><span class="dot"></span>⏱️ 5 mins</div>
-      <h3 class="product-name">${p.name}</h3>
-      <div class="eta">${p.variants && p.variants[0] ? p.variants[0].label : '1 pc'}</div>
-      <div class="price-row">
-        <span class="price">$${p.price.toFixed(2)}</span>
-        ${p.mrp ? `<span class="mrp">$${p.mrp.toFixed(2)}</span>` : ''}
-      </div>
-      <div class="tagline">Har Din Sasta!</div>
-      <div class="add-section">
-        <button class="qty-btn plus main" ${p.stock > 0 ? '' : 'disabled'}>+</button>
-      </div>
+      ${discount > 0 ? `<span class="disc">${discount}% OFF</span>` : ''}
+      <img src="${p.image}" alt="${p.name}" loading="lazy" onerror="this.onerror=null;this.src='https://via.placeholder.com/150'" />
+      <span class="timer">⏱ 5 mins</span>
+      <p class="name">${p.name}</p>
+      <p class="qty">${qtyLabel}</p>
+      <p class="price">₹${p.price} ${p.mrp ? `<del>₹${p.mrp}</del>` : ''}</p>
+      ${qty === 0
+        ? `<button class="add" data-id="${p.id}">ADD +</button>`
+        : `<div class="counter" data-id="${p.id}">
+             <button class="minus">−</button>
+             <span>${qty}</span>
+             <button class="plus">+</button>
+           </div>`}
     `;
-    const plusMain = card.querySelector('.add-section .plus');
-    const controls = card.querySelector('.qty-controls');
-    const plus = card.querySelector('.qty-controls .plus');
-    const minus = card.querySelector('.qty-controls .minus');
-    const qtySpan = card.querySelector('.qty-controls .qty');
+    const addBtn = card.querySelector('.add');
+    const counter = card.querySelector('.counter');
+    const plus = card.querySelector('.counter .plus');
+    const minus = card.querySelector('.counter .minus');
+    const qtySpan = counter ? counter.querySelector('span') : null;
     const update = (newQty) => {
-      qtySpan.textContent = newQty;
-      controls.classList.toggle('hidden', newQty === 0);
-      plusMain.style.display = newQty === 0 ? 'block' : 'none';
+      if (qtySpan) qtySpan.textContent = newQty;
+      if (counter) counter.style.display = newQty ? 'flex' : 'none';
+      if (addBtn) addBtn.style.display = newQty ? 'none' : 'block';
     };
     update(qty);
     if (p.stock > 0) {
-      plusMain.onclick = e => { e.stopPropagation(); cartAdd(p.id); update(parseInt(qtySpan.textContent)+1); };
-      plus.onclick = e => { e.stopPropagation(); cartAdd(p.id); update(parseInt(qtySpan.textContent)+1); };
-      minus.onclick = e => { e.stopPropagation(); updateQty(p.id, null, parseInt(qtySpan.textContent)-1); update(parseInt(qtySpan.textContent)-1); };
+      if (addBtn) addBtn.onclick = e => { e.stopPropagation(); cartAdd(p.id); update(1); };
+      if (plus) plus.onclick = e => { e.stopPropagation(); cartAdd(p.id); update(parseInt(qtySpan.textContent)+1); };
+      if (minus) minus.onclick = e => { e.stopPropagation(); updateQty(p.id, null, parseInt(qtySpan.textContent)-1); update(parseInt(qtySpan.textContent)-1); };
       card.onclick = () => openModal(p);
     }
     container.appendChild(card);
@@ -199,7 +193,7 @@ function showRecommendations() {
   container.innerHTML = '';
   recommended.forEach(p => {
     const card = document.createElement('div');
-    card.className = 'product-card';
+    card.className = 'card';
     card.innerHTML = `<img src="${p.image}" alt="${p.name}" /><h3>${p.name}</h3><p>$${p.price.toFixed(2)}</p>`;
     card.onclick = () => openModal(p);
     container.appendChild(card);
@@ -249,7 +243,7 @@ function showSkeletons() {
   container.innerHTML = '';
   for(let i=0;i<4;i++) {
     const card = document.createElement('div');
-    card.className = 'product-card skeleton';
+    card.className = 'card skeleton';
     container.appendChild(card);
   }
 }

--- a/frontend/assets/icons/arrow-left.svg
+++ b/frontend/assets/icons/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M15 18l-6-6 6-6"/>
+</svg>

--- a/frontend/assets/icons/baby.svg
+++ b/frontend/assets/icons/baby.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8"/>
+</svg>

--- a/frontend/assets/icons/bread.svg
+++ b/frontend/assets/icons/bread.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8"/>
+</svg>

--- a/frontend/assets/icons/care.svg
+++ b/frontend/assets/icons/care.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8"/>
+</svg>

--- a/frontend/assets/icons/chips.svg
+++ b/frontend/assets/icons/chips.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8"/>
+</svg>

--- a/frontend/assets/icons/drink.svg
+++ b/frontend/assets/icons/drink.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8"/>
+</svg>

--- a/frontend/assets/icons/home.svg
+++ b/frontend/assets/icons/home.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8"/>
+</svg>

--- a/frontend/assets/icons/meat.svg
+++ b/frontend/assets/icons/meat.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8"/>
+</svg>

--- a/frontend/assets/icons/veg.svg
+++ b/frontend/assets/icons/veg.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8"/>
+</svg>

--- a/frontend/categories.js
+++ b/frontend/categories.js
@@ -1,14 +1,10 @@
 export const categories = [
-  { id: 'electronics', label: 'Electronics', icon: 'earphones' },
-  { id: 'fashion', label: 'Fashion', icon: 'tshirt' },
-  { id: 'food', label: 'Food Court', icon: 'bowl' },
-  { id: 'wellness', label: 'Pharmacy & Wellness', icon: 'pill' },
-  { id: 'fv', label: 'Fruits & Vegetables', icon: 'apple' },
-  { id: 'beverages', label: 'Beverages', icon: 'bottle' },
-  { id: 'home', label: 'Home & Kitchen', icon: 'home' },
-  { id: 'beauty', label: 'Beauty & Hygiene', icon: 'lipstick' },
-  { id: 'bakery', label: 'Bakery', icon: 'bread' },
-  { id: 'baby', label: 'Baby Care', icon: 'pacifier' },
-  { id: 'meat', label: 'Meat & Seafood', icon: 'fish' },
-  { id: 'gourmet', label: 'Gourmet', icon: 'cheese' }
+  { slug: 'fresh-veg', label: 'Fruits & Vegetables', icon: 'veg.svg' },
+  { slug: 'snacks', label: 'Snacks & Branded Food', icon: 'chips.svg' },
+  { slug: 'beverages', label: 'Beverages', icon: 'drink.svg' },
+  { slug: 'bakery', label: 'Bakery & Dairy', icon: 'bread.svg' },
+  { slug: 'household', label: 'Household', icon: 'home.svg' },
+  { slug: 'personal-care', label: 'Personal Care', icon: 'care.svg' },
+  { slug: 'baby', label: 'Baby Care', icon: 'baby.svg' },
+  { slug: 'meat', label: 'Meat & Seafood', icon: 'meat.svg' }
 ];

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,16 @@
   <link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
 </head>
 <body>
+  <aside id="catSheet" class="sheet hidden">
+    <header class="sheet-bar">
+      <button id="catBack" aria-label="Back">
+        <img src="assets/icons/arrow-left.svg" alt="">
+      </button>
+      <h2>SHOP BY CATEGORY</h2>
+    </header>
+    <ul id="catList"></ul>
+  </aside>
+  <div id="sheetBackdrop" class="backdrop hidden"></div>
   <div class="frame page">
     <header class="frame header-frame">
       <div class="header-row1">
@@ -130,7 +140,7 @@
         <span class="icon" aria-hidden="true">🏠</span>
         <span class="label">Home</span>
       </button>
-      <button class="navBtn" data-page="categories">
+      <button class="navBtn" data-page="categories" id="hamburger">
         <span class="icon">🗂️</span>
         <span class="label">Categories</span>
       </button>
@@ -159,15 +169,6 @@
   <script src="main.js"></script>
   <script type="module" src="ui.js"></script>
   <script src="footer.js"></script>
-  <aside id="categorySheet" class="sheet hidden">
-    <header class="sheet-bar">
-      <button id="catBack" class="backBtn" aria-label="Back">
-        <svg viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M15 18l-6-6 6-6" stroke="currentColor"/></svg>
-      </button>
-      <h2>SHOP BY CATEGORY</h2>
-    </header>
-    <ul id="catList"></ul>
-  </aside>
   <nav id="sideMenu" role="navigation" aria-label="Main menu">
     <div class="menu-header">
       <a href="auth/login.html" class="menu-item" tabindex="0">Login / Signup</a>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -94,6 +94,10 @@
 
 .hidden { display: none; }
 
+input, select, textarea {
+  font-size: 16px;
+}
+
 body {
   font-family: 'Poppins', sans-serif;
   margin: 0;
@@ -113,6 +117,7 @@ body {
   flex: 1;
   margin: 0;
   padding: 8px;
+  font-size: 16px;
   border: 1px solid #ccc;
   border-radius: 20px;
 }
@@ -126,6 +131,7 @@ body {
 }
 .pin-input {
   width: 80px;
+  font-size: 16px;
 }
 
 .drawer {
@@ -146,114 +152,76 @@ body {
 .drawer a { margin: 10px 0; color: var(--text); text-decoration: none; }
 .drawer.open { transform: translateX(0); }
 
-.mobile-login input { width: 100%; margin-bottom: 8px; padding: 8px; }
+.mobile-login input { width: 100%; margin-bottom: 8px; padding: 8px; font-size: 16px; }
 .mobile-login button { padding: 0.5rem; }
+
 .product-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 15px;
-  padding: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+  padding: 15px;
 }
-.product-card {
+
+.card {
+  position: relative;
   background: #fff;
-  padding: 12px;
-  border-radius: 8px;
   border: 1px solid #eee;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-  cursor: pointer;
-  transition: transform 0.2s, box-shadow 0.2s;
+  border-radius: 8px;
+  padding: 8px;
   text-align: center;
   display: flex;
   flex-direction: column;
-  position: relative;
 }
-.product-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
-}
-.product-card img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 6px;
-}
-.image-container {
-  position: relative;
-  width: 100%;
-  height: 150px;
-  overflow: hidden;
-  margin-bottom: 8px;
-}
-.offer-tag {
+.card img { width: 100%; border-radius: 4px; }
+.disc {
   position: absolute;
   top: 6px;
   left: 6px;
-  background: var(--primary);
+  background: #e53935;
   color: #fff;
-  padding: 2px 6px;
-  font-size: 10px;
+  font-size: 12px;
+  padding: 2px 4px;
   border-radius: 4px;
 }
-.delivery-label {
-  display: flex;
-  align-items: center;
+.timer {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: #fff;
   font-size: 12px;
-  color: #888;
-  margin-bottom: 4px;
+  padding: 2px 4px;
+  border-radius: 4px;
 }
-.delivery-label .dot {
-  width: 6px;
-  height: 6px;
-  background: gold;
-  border-radius: 50%;
-  margin-right: 4px;
-}
-.price-row { display:flex; gap:4px; align-items:center; }
-.tagline { font-size: 0.75em; color: var(--primary); }
-.qty-controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
+.name { font-weight: 600; margin: 6px 0 2px; }
+.qty { color: #777; font-size: 0.85em; margin-bottom: 4px; }
+.price { font-weight: 600; }
+.price del { color: #777; margin-left: 4px; }
+.add {
   margin-top: 6px;
-}
-.qty-controls.hidden { display: none; }
-.qty-btn {
-  background: var(--accent);
+  background: var(--accent, #4CAF50);
   color: #fff;
   border: none;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  line-height: 24px;
-  text-align: center;
-  font-size: 16px;
-}
-.add-section { display:flex; justify-content:center; margin-top:6px; }
-.add-section .qty-btn.main { width:28px; height:28px; }
-.product-card button {
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  padding: 0.5rem;
+  padding: 4px 8px;
   border-radius: 4px;
   cursor: pointer;
 }
-.product-card button:disabled {
-  background: #ccc;
-  cursor: not-allowed;
-}
-.card-footer {
-  margin-top: auto;
+.counter {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
+  margin-top: 6px;
 }
-.price { font-weight: 600; }
-.mrp { text-decoration: line-through; color: #777; font-size: 0.9em; }
-.product-name { font-weight: 600; margin: 4px 0; font-size: 0.95em; }
-.eta { font-size: 0.8em; color: #555; }
+.counter button {
+  width: 24px;
+  height: 24px;
+  background: var(--accent, #4CAF50);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  line-height: 24px;
+}
+.counter span { min-width: 20px; text-align: center; }
 .skeleton {
   background: linear-gradient(90deg, #eee 25%, #ddd 37%, #eee 63%);
   background-size: 400% 100%;
@@ -263,9 +231,7 @@ body {
   0% { background-position: 100% 0; }
   100% { background-position: -100% 0; }
 }
-.product-card.skeleton {
-  height: 220px;
-}
+.card.skeleton { height: 160px; }
 .modal {
   position: fixed;
   top: 0;
@@ -308,6 +274,10 @@ body {
   flex-wrap: wrap;
   gap: 10px;
   z-index: 5;
+}
+.filter-panel input,
+.filter-panel select {
+  font-size: 16px;
 }
 .filter-panel.hidden { display: none; }
 .tags { display: flex; flex-wrap: wrap; gap: 5px; padding: 5px 10px; }
@@ -377,15 +347,15 @@ body {
   background: var(--bg);
   color: var(--text);
 }
-.dark .product-card {
+.dark .card {
   background: #333;
 }
-.product-card.out-of-stock {
+.card.out-of-stock {
   position: relative;
   opacity: 0.6;
   background: #f5f5f5;
 }
-.product-card.out-of-stock::after {
+.card.out-of-stock::after {
   content: 'Out of Stock';
   position: absolute;
   top: 50%;
@@ -396,7 +366,7 @@ body {
   padding: 5px 10px;
   border-radius: 4px;
 }
-.product-card.in-stock {
+.card.in-stock {
   background: #fff;
 }
 
@@ -428,7 +398,7 @@ body {
     background: white;
     padding: 0.5rem;
   }
-  #recommended.mobile-scroll .product-card {
+  #recommended.mobile-scroll .card {
     flex: 0 0 150px;
   }
   .filter-panel {
@@ -461,13 +431,18 @@ body {
 .bottom-nav .nav-item.active { color: var(--primary); }
 .bottom-nav .badge {
   position: absolute;
-  top: 0;
-  right: 0.6rem;
+  top: -4px;
+  right: -4px;
   background: var(--accent);
   color: #fff;
-  border-radius: 10px;
-  padding: 0 4px;
-  font-size: 10px;
+  border-radius: 9px;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
 }
 .bottom-nav .material-icons {
   font-size: 1.4em;
@@ -519,6 +494,15 @@ body {
 #backdrop.open {
   display: block;
 }
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 998;
+}
+.backdrop.hidden {
+  display: none;
+}
 @media (min-width: 768px) {
   #sideMenu, #backdrop { display: none !important; }
 }
@@ -531,7 +515,7 @@ body {
 .location-bar { display: flex; align-items: center; gap: 6px; background: #fff; border-radius: 6px; padding: 0.25rem 0.5rem; font-size: 0.85em; }
 .loc-title { font-weight: 600; }
 .search-wrapper { display: flex; align-items: center; background: #fff; border-radius: 20px; padding: 0 0.5rem; }
-.search-wrapper input { border: none; outline: none; padding: 0.4rem 0.5rem; flex: 1; }
+.search-wrapper input { border: none; outline: none; padding: 0.4rem 0.5rem; flex: 1; font-size: 16px; }
 .search-wrapper .search-icon { color: #666; }
 .sheet           { position: fixed; inset:0; background:#fff; z-index:999; overflow-y:auto; }
 .sheet.hidden    { display:none; }
@@ -539,6 +523,8 @@ body {
                      align-items:center; justify-content:center; position:sticky; top:0; }
 .backBtn         { position:absolute; left:16px; background:none; border:none; padding:0; }
 .backBtn svg     { width:24px; height:24px; stroke:#fff; }
+#catBack         { position:absolute; left:16px; background:none; border:none; padding:0; }
+#catBack img     { width:24px; height:24px; }
 #catList         { list-style:none; padding:0; margin:0; }
 .catItem         { display:flex; gap:12px; width:100%; padding:18px 20px; border:none;
                      background:#fff; font:16px/1.4 "Inter",sans-serif; text-align:left; }
@@ -552,7 +538,7 @@ body {
 .navBtn .icon    { font-size:24px; line-height:1; }
 .navBtn .icon svg{ width:24px; height:24px; }
 .navBtn.active   { color:#4CAF50; }
-.badge           { position:absolute; top:2px; right:6px; background:#F44336; color:#fff;
-                     border-radius:8px; width:16px; height:16px; display:flex; align-items:center;
-                     justify-content:center; font-size:11px; font-weight:700; }
+.badge           { position:absolute; top:-4px; right:-4px; background:#F44336; color:#fff;
+                    border-radius:9px; width:18px; height:18px; display:flex; align-items:center;
+                    justify-content:center; font-size:11px; font-weight:700; }
 .badge.hidden    { display:none; }

--- a/frontend/ui.js
+++ b/frontend/ui.js
@@ -1,58 +1,30 @@
 import { categories } from './categories.js';
 
-const sheet = document.getElementById('categorySheet');
-const list = document.getElementById('catList');
-const backBtn = document.getElementById('catBack');
-const catBtn = document.querySelector('[data-page="categories"]');
+const $ = s => document.querySelector(s);
 
-function iconSVG(name) {
-  const icons = {
-    earphones: '<svg viewBox="0 0 24 24"><path d="M5 12v3a2 2 0 0 0 4 0v-3M15 12v3a2 2 0 0 0 4 0v-3M5 12a7 7 0 0 1 14 0" stroke="currentColor" fill="none"/></svg>',
-    tshirt: '<svg viewBox="0 0 24 24"><path d="M4 5l4-2 4 2 4-2 4 2v3l-2 3v9h-8v-9l-2-3V5z" stroke="currentColor" fill="none"/></svg>',
-    bowl: '<svg viewBox="0 0 24 24"><path d="M4 10h16a8 8 0 0 1-16 0z" stroke="currentColor" fill="none"/><path d="M2 10h20" stroke="currentColor"/></svg>',
-    pill: '<svg viewBox="0 0 24 24"><rect x="3" y="9" width="8" height="8" rx="4" stroke="currentColor" fill="none"/><rect x="13" y="7" width="8" height="10" rx="5" stroke="currentColor" fill="none"/></svg>',
-    apple: '<svg viewBox="0 0 24 24"><path d="M12 2c1.5 0 2.5 1 2.5 2.5S13 7 12 7 9.5 6 9.5 4.5 10.5 2 12 2zM8 9c-2 2-2 5 0 7s4 3 4 3 2-1 4-3 2-5 0-7-3.6-2-4-2-2 0-4 2z" stroke="currentColor" fill="none"/></svg>',
-    bottle: '<svg viewBox="0 0 24 24"><path d="M10 2h4v4l2 3v11a2 2 0 0 1-2 2h-4a2 2 0 0 1-2-2V9l2-3V2z" stroke="currentColor" fill="none"/></svg>',
-    home: '<svg viewBox="0 0 24 24"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2h-4a2 2 0 0 1-2-2v-5H9v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" fill="none"/></svg>',
-    lipstick: '<svg viewBox="0 0 24 24"><path d="M8 15v5h8v-5M10 15v-4l2-6 2 6v4" stroke="currentColor" fill="none"/></svg>',
-    bread: '<svg viewBox="0 0 24 24"><path d="M3 11a9 9 0 0 1 18 0v7H3v-7z" stroke="currentColor" fill="none"/><path d="M3 16h18" stroke="currentColor"/></svg>',
-    pacifier: '<svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="3" stroke="currentColor" fill="none"/><path d="M9 11l-2 7h10l-2-7" stroke="currentColor" fill="none"/></svg>',
-    fish: '<svg viewBox="0 0 24 24"><path d="M2 12s3-5 10-5 10 5 10 5-3 5-10 5S2 12 2 12z" stroke="currentColor" fill="none"/><circle cx="14" cy="12" r="1" fill="currentColor"/></svg>',
-    cheese: '<svg viewBox="0 0 24 24"><path d="M3 14l9-5 9 5v5H3v-5z" stroke="currentColor" fill="none"/><circle cx="9" cy="15" r="1" fill="currentColor"/><circle cx="15" cy="17" r="1" fill="currentColor"/></svg>'
-  };
-  return icons[name] || '';
+const sheet    = $('#catSheet');
+const catList  = $('#catList');
+const backdrop = $('#sheetBackdrop');
+
+catList.innerHTML = categories.map(c => `
+  <li><button class="catItem" data-slug="${c.slug}">
+    <img src="assets/icons/${c.icon}" alt="">
+    <span>${c.label}</span>
+  </button></li>`).join('');
+
+$('#hamburger').onclick = () => openSheet(true);
+$('#catBack').onclick   = () => openSheet(false);
+backdrop.onclick        = () => openSheet(false);
+
+function openSheet(on) {
+  sheet.classList.toggle('hidden', !on);
+  sheet.classList.toggle('open',   on);
+  backdrop.classList.toggle('hidden', !on);
 }
 
-if (list) {
-  list.innerHTML = categories
-    .map(c => `<li><button class="catItem" data-slug="${c.id}">` +
-               `<span class="icon">${iconSVG(c.icon)}</span>` +
-               `<span class="label">${c.label}</span>` +
-               `</button></li>`)
-    .join('');
-
-  list.addEventListener('click', e => {
-    const item = e.target.closest('.catItem');
-    if (!item) return;
-    const label = item.querySelector('.label').textContent;
-    const filter = document.getElementById('categoryFilter');
-    if (filter) {
-      filter.value = label;
-      if (typeof applyFilters === 'function') applyFilters();
-    }
-    closeSheet();
-  });
-}
-
-function openSheet() {
-  sheet.classList.remove('hidden');
-}
-
-function closeSheet() {
-  sheet.classList.add('hidden');
-}
-
-if (catBtn) catBtn.onclick = e => { e.preventDefault(); openSheet(); };
-if (backBtn) backBtn.onclick = closeSheet;
-
-
+catList.addEventListener('click', e => {
+  const btn = e.target.closest('.catItem');
+  if (!btn) return;
+  location.href = `category.html?c=${btn.dataset.slug}`;
+  openSheet(false);
+});


### PR DESCRIPTION
## Summary
- add new category sheet markup near the page body tag
- drop old `categorySheet` element
- style the new sheet and backdrop
- update JavaScript to reference `catSheet`
- switch to data-driven category list and new open/close logic
- refactor product card markup and styles
- fine-tune badge and input field styling

## Testing
- `node test.js`